### PR TITLE
docs: update README with frontend and monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,37 @@
 # EDI Healthcare
 
-A Spring Boot multi-module monorepo for processing EDI (Electronic Data Interchange) healthcare transactions. Supports generating EDI 837P professional claims, EDI 270 eligibility inquiries, and parsing EDI 271 eligibility responses.
+A monorepo for processing EDI (Electronic Data Interchange) healthcare transactions. Includes a Spring Boot backend for generating EDI 837P professional claims, EDI 270 eligibility inquiries, and parsing EDI 271 eligibility responses, plus a Next.js frontend with a BFF (Backend-For-Frontend) API layer.
 
 ## Tech Stack
 
+### Backend
 - **Java 21** / **Spring Boot 4.0.4**
 - **MongoDB 7** (via Docker)
 - **StAEDI 1.25.3** — EDI X12 generation and parsing
 - **Gradle** — multi-module build
 - **SpringDoc OpenAPI 3.0.2** — Swagger UI
 - **Testcontainers** — integration testing
+
+### Frontend
+- **Next.js 16** / **React 19** / **TypeScript**
+- **Tailwind CSS 4**
+- **BFF API routes** — server-side proxies to backend services
+
+## Project Structure
+
+```
+backend/                          # Java modules (Gradle build at root)
+  common/                         # Shared MongoDB entities and repositories
+  claims-app/                     # EDI 837 claims generation (port 8080)
+  insurance-request-app/          # EDI 270 eligibility requests (port 8081)
+  insurance-response-app/         # EDI 271 response parsing (port 8082)
+frontend/                         # Next.js app with BFF API routes (port 3000)
+  src/app/                        # Pages and API routes
+  src/lib/                        # Shared utilities
+  src/types/                      # TypeScript interfaces
+```
+
+Gradle config (`settings.gradle`, `build.gradle`) stays at the repo root. Module names are preserved via `projectDir` remapping — use `:claims-app:build` (not `:backend:claims-app:build`).
 
 ## Modules
 
@@ -19,34 +41,69 @@ A Spring Boot multi-module monorepo for processing EDI (Electronic Data Intercha
 | **claims-app** | 8080 | Generates EDI 837P professional claims |
 | **insurance-request-app** | 8081 | Generates EDI 270 eligibility inquiries |
 | **insurance-response-app** | 8082 | Parses EDI 271 eligibility responses |
+| **frontend** | 3000 | Next.js UI with BFF API routes |
 
 ## Getting Started
 
 ### Prerequisites
 
 - Java 21
+- Node.js 20+
 - Docker & Docker Compose
 
 ### Start MongoDB
 
 ```bash
-docker-compose up -d
+docker-compose up -d mongodb
 ```
 
-### Build
+### Build & Run Backend
 
 ```bash
+# Build all modules
 ./gradlew build
-```
 
-### Run
-
-```bash
 # Run individual apps
 ./gradlew :claims-app:bootRun              # port 8080
 ./gradlew :insurance-request-app:bootRun   # port 8081
 ./gradlew :insurance-response-app:bootRun  # port 8082
 ```
+
+### Build & Run Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev    # port 3000
+```
+
+### Full Stack Local Dev
+
+```bash
+# 1. Start MongoDB
+docker-compose up -d mongodb
+
+# 2. Start backend services (each in its own terminal)
+./gradlew :claims-app:bootRun              # port 8080
+./gradlew :insurance-request-app:bootRun   # port 8081
+./gradlew :insurance-response-app:bootRun  # port 8082
+
+# 3. Start frontend
+cd frontend && npm run dev                 # port 3000
+```
+
+Open http://localhost:3000 to access the dashboard. Use the "Seed Database" button to populate test data.
+
+## Frontend
+
+The Next.js frontend provides a UI for all three EDI workflows:
+
+- **Dashboard** — Overview with seed database button and links to workflows
+- **Claims (837)** — Enter encounter IDs to generate and download EDI 837 claim files
+- **Eligibility Request (270)** — Enter patient IDs to generate and download EDI 270 inquiry files
+- **Eligibility Response (271)** — Upload EDI 271 files to view parsed coverage details, benefits, and subscriber info
+
+The frontend uses the BFF pattern — API routes in `frontend/src/app/api/` proxy requests to the backend services server-side. The browser never calls backend ports directly.
 
 ## API Endpoints
 
@@ -79,7 +136,7 @@ Creates sample patients, encounters, diagnoses, procedures, and related entities
 POST /api/insurance/eligibility-request
 Content-Type: application/json
 
-{"patientId": "patient_id"}
+{"patientIds": ["patient_id1", "patient_id2"]}
 ```
 
 Returns a downloadable `270_inquiry.edi` file.
@@ -95,25 +152,19 @@ Content-Type: multipart/form-data
 file: <271_response.edi>
 ```
 
-Returns:
-
-```json
-{
-  "patientId": "MEMBER001",
-  "status": "ACTIVE",
-  "verificationMessage": "ELIGIBLE"
-}
-```
+Returns parsed eligibility details including subscriber info, payer, coverage dates, and benefits.
 
 ### Swagger UI
 
-Each running app exposes interactive API docs:
+Each running backend app exposes interactive API docs:
 
 - Claims: http://localhost:8080/swagger-ui.html
 - Insurance Request: http://localhost:8081/swagger-ui.html
 - Insurance Response: http://localhost:8082/swagger-ui.html
 
 ## Architecture
+
+### Backend Layer Structure
 
 ```
 Controller → Service → Repository (common) + EDI Service
@@ -123,6 +174,16 @@ Controller → Service → Repository (common) + EDI Service
 - **Services** orchestrate repository lookups and EDI generation/parsing
 - **EDI Services** (`EDI837Generator`, `EDI270Service`, `EDI271Service`) contain pure business logic with no repository access
 - **Common module** provides shared MongoDB `@Document` entities and `MongoRepository` interfaces
+
+### Frontend Architecture
+
+```
+Browser → Next.js Pages → BFF API Routes → Backend Services
+```
+
+- **Pages** (`src/app/*/page.tsx`) — client components with forms and result display
+- **BFF Routes** (`src/app/api/*/route.ts`) — server-side proxies forwarding requests to backend services
+- **API Client** (`src/lib/api-client.ts`) — shared fetch helpers for calling BFF routes
 
 ### Data Model
 
@@ -138,11 +199,12 @@ The common module defines these MongoDB collections:
 - `encounter_procedures` — CPT codes with charges and diagnosis pointers
 - `payers` — insurance payer directory
 - `companies` — submitter/receiver organizations
+- `eligibility_responses` — parsed EDI 271 response data
 
 ## Testing
 
 ```bash
-# Run all tests
+# Run all backend tests
 ./gradlew test
 
 # Run tests for a specific module
@@ -152,9 +214,23 @@ The common module defines these MongoDB collections:
 
 # Run a single test class
 ./gradlew :claims-app:test --tests "com.example.edi.claims.service.EDI837ServiceTest"
+
+# Lint and build frontend
+cd frontend && npm run lint && npm run build
 ```
 
 Integration tests use Testcontainers to spin up a MongoDB instance automatically.
+
+## CI/CD
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on pushes to `main` and on pull requests:
+
+- **test** — Runs all backend tests with a real MongoDB instance
+- **test-frontend** — Lints and builds the frontend
+- **detect-changes** — Identifies which apps changed to build/deploy only what's needed
+- **build-and-push** — Builds Docker images and pushes to Google Artifact Registry (main branch only)
+- **deploy-dev** — Auto-deploys to Cloud Run dev on push to main
+- **deploy-prod** — Manual deployment via workflow_dispatch
 
 ## Project Conventions
 


### PR DESCRIPTION
Reflect the backend/frontend monorepo layout, add Next.js frontend section with BFF architecture, full-stack local dev instructions, CI/CD overview, and updated project structure diagram.