### PR TITLE
fix: return proper HTTP error codes for entity-not-found and parse er…

### DIFF
--- a/backend/claims-app/src/main/java/com/example/edi/claims/controller/GlobalExceptionHandler.java
+++ b/backend/claims-app/src/main/java/com/example/edi/claims/controller/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.example.edi.claims.controller;
+
+import com.example.edi.common.dto.ErrorResponse;
+import com.example.edi.common.exception.EdiParseException;
+import com.example.edi.common.exception.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(404)
+                .body(ErrorResponse.notFound(ex.getEntityType(), ex.getEntityId()));
+    }
+
+    @ExceptionHandler(EdiParseException.class)
+    public ResponseEntity<ErrorResponse> handleEdiParse(EdiParseException ex) {
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.badRequest(ex.getMessage()));
+    }
+}

--- a/backend/claims-app/src/main/java/com/example/edi/claims/service/ClaimsService.java
+++ b/backend/claims-app/src/main/java/com/example/edi/claims/service/ClaimsService.java
@@ -4,6 +4,7 @@ import com.example.edi.claims.config.InterchangeProperties;
 import com.example.edi.claims.domain.loop.EDI837Claim;
 import com.example.edi.claims.dto.EncounterBundle;
 import com.example.edi.common.document.*;
+import com.example.edi.common.exception.*;
 import com.example.edi.common.repository.*;
 import org.springframework.stereotype.Service;
 
@@ -58,18 +59,17 @@ public class ClaimsService {
 
         for (String encounterId : encounterIds) {
             Encounter encounter = encounterRepository.findById(encounterId)
-                    .orElseThrow(() -> new RuntimeException("Encounter not found: " + encounterId));
+                    .orElseThrow(() -> new EncounterNotFoundException(encounterId));
 
             Patient patient = patientRepository.findById(encounter.getPatientId())
-                    .orElseThrow(() -> new RuntimeException("Patient not found: " + encounter.getPatientId()));
+                    .orElseThrow(() -> new PatientNotFoundException(encounter.getPatientId()));
 
             PatientInsurance insurance = patientInsuranceRepository
                     .findByPatientIdAndTerminationDateIsNull(encounter.getPatientId())
-                    .orElseThrow(() -> new RuntimeException(
-                            "Active insurance not found for patient: " + encounter.getPatientId()));
+                    .orElseThrow(() -> new InsuranceNotFoundException(encounter.getPatientId()));
 
             Payer payer = payerRepository.findById(insurance.getPayerId())
-                    .orElseThrow(() -> new RuntimeException("Payer not found: " + insurance.getPayerId()));
+                    .orElseThrow(() -> new PayerNotFoundException(insurance.getPayerId()));
 
             List<EncounterDiagnosis> diagnoses =
                     encounterDiagnosisRepository.findByEncounterIdOrderByRankAsc(encounterId);
@@ -79,11 +79,11 @@ public class ClaimsService {
 
             if (practice == null) {
                 practice = practiceRepository.findById(encounter.getPracticeId())
-                        .orElseThrow(() -> new RuntimeException("Practice not found: " + encounter.getPracticeId()));
+                        .orElseThrow(() -> new PracticeNotFoundException(encounter.getPracticeId()));
             }
 
             Facility facility = facilityRepository.findById(encounter.getFacilityId())
-                    .orElseThrow(() -> new RuntimeException("Facility not found: " + encounter.getFacilityId()));
+                    .orElseThrow(() -> new FacilityNotFoundException(encounter.getFacilityId()));
 
             bundles.add(new EncounterBundle(patient, insurance, payer, encounter, diagnoses, procedures, facility));
         }

--- a/backend/claims-app/src/test/java/com/example/edi/claims/ClaimsGenerationIT.java
+++ b/backend/claims-app/src/test/java/com/example/edi/claims/ClaimsGenerationIT.java
@@ -267,7 +267,7 @@ class ClaimsGenerationIT {
     }
 
     @Test
-    void generateClaim_unknownEncounter_returns500() {
+    void generateClaim_unknownEncounter_returns404() {
         Map<String, Object> requestBody = Map.of("encounterIds", List.of("NONEXISTENT"));
 
         ResponseEntity<String> response = restTemplate.postForEntity(
@@ -276,7 +276,7 @@ class ClaimsGenerationIT {
                 String.class
         );
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     private int countOccurrences(String text, String sub) {

--- a/backend/claims-app/src/test/java/com/example/edi/claims/controller/ClaimsControllerTest.java
+++ b/backend/claims-app/src/test/java/com/example/edi/claims/controller/ClaimsControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.edi.claims.controller;
 
 import com.example.edi.claims.service.ClaimsService;
+import com.example.edi.common.exception.EncounterNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -56,6 +57,22 @@ class ClaimsControllerTest {
                                 {"encounterIds": []}
                                 """))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void generateClaim_encounterNotFound_returns404() throws Exception {
+        when(claimsService.generateClaim(List.of("ENC001")))
+                .thenThrow(new EncounterNotFoundException("ENC001"));
+
+        mockMvc.perform(post("/api/claims/generate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"encounterIds": ["ENC001"]}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.entityType").value("Encounter"))
+                .andExpect(jsonPath("$.entityId").value("ENC001"));
     }
 
 }

--- a/backend/claims-app/src/test/java/com/example/edi/claims/service/ClaimsServiceTest.java
+++ b/backend/claims-app/src/test/java/com/example/edi/claims/service/ClaimsServiceTest.java
@@ -4,6 +4,9 @@ import com.example.edi.claims.config.InterchangeProperties;
 import com.example.edi.claims.domain.loop.EDI837Claim;
 import com.example.edi.claims.dto.EncounterBundle;
 import com.example.edi.common.document.*;
+import com.example.edi.common.exception.EncounterNotFoundException;
+import com.example.edi.common.exception.InsuranceNotFoundException;
+import com.example.edi.common.exception.PatientNotFoundException;
 import com.example.edi.common.repository.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,24 +86,24 @@ class ClaimsServiceTest {
     }
 
     @Test
-    void generateClaim_encounterNotFound_throwsException() {
+    void generateClaim_encounterNotFound_throwsEncounterNotFoundException() {
         when(encounterRepository.findById(anyString())).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> claimsService.generateClaim(List.of("ENC001")));
+        assertThrows(EncounterNotFoundException.class, () -> claimsService.generateClaim(List.of("ENC001")));
     }
 
     @Test
-    void generateClaim_patientNotFound_throwsException() {
+    void generateClaim_patientNotFound_throwsPatientNotFoundException() {
         Encounter encounter = new Encounter();
         encounter.setPatientId("P001");
         when(encounterRepository.findById(anyString())).thenReturn(Optional.of(encounter));
         when(patientRepository.findById(anyString())).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> claimsService.generateClaim(List.of("ENC001")));
+        assertThrows(PatientNotFoundException.class, () -> claimsService.generateClaim(List.of("ENC001")));
     }
 
     @Test
-    void generateClaim_activeInsuranceNotFound_throwsException() {
+    void generateClaim_activeInsuranceNotFound_throwsInsuranceNotFoundException() {
         Encounter encounter = new Encounter();
         encounter.setPatientId("P001");
         Patient patient = new Patient();
@@ -108,6 +111,6 @@ class ClaimsServiceTest {
         when(patientRepository.findById(anyString())).thenReturn(Optional.of(patient));
         when(patientInsuranceRepository.findByPatientIdAndTerminationDateIsNull(anyString())).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> claimsService.generateClaim(List.of("ENC001")));
+        assertThrows(InsuranceNotFoundException.class, () -> claimsService.generateClaim(List.of("ENC001")));
     }
 }

--- a/backend/common/src/main/java/com/example/edi/common/dto/ErrorResponse.java
+++ b/backend/common/src/main/java/com/example/edi/common/dto/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.example.edi.common.dto;
+
+public record ErrorResponse(
+        String error,
+        String message,
+        String entityType,
+        String entityId
+) {
+
+    public static ErrorResponse notFound(String entityType, String entityId) {
+        return new ErrorResponse("NOT_FOUND", entityType + " not found: " + entityId, entityType, entityId);
+    }
+
+    public static ErrorResponse badRequest(String message) {
+        return new ErrorResponse("BAD_REQUEST", message, null, null);
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/EdiParseException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/EdiParseException.java
@@ -1,0 +1,8 @@
+package com.example.edi.common.exception;
+
+public class EdiParseException extends RuntimeException {
+
+    public EdiParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/EncounterNotFoundException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/EncounterNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.edi.common.exception;
+
+public class EncounterNotFoundException extends EntityNotFoundException {
+
+    public EncounterNotFoundException(String id) {
+        super("Encounter", id);
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/EntityNotFoundException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/EntityNotFoundException.java
@@ -1,0 +1,21 @@
+package com.example.edi.common.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+
+    private final String entityType;
+    private final String entityId;
+
+    public EntityNotFoundException(String entityType, String entityId) {
+        super(entityType + " not found: " + entityId);
+        this.entityType = entityType;
+        this.entityId = entityId;
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/FacilityNotFoundException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/FacilityNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.edi.common.exception;
+
+public class FacilityNotFoundException extends EntityNotFoundException {
+
+    public FacilityNotFoundException(String id) {
+        super("Facility", id);
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/InsuranceNotFoundException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/InsuranceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.edi.common.exception;
+
+public class InsuranceNotFoundException extends EntityNotFoundException {
+
+    public InsuranceNotFoundException(String patientId) {
+        super("Insurance", patientId);
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/PatientNotFoundException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/PatientNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.edi.common.exception;
+
+public class PatientNotFoundException extends EntityNotFoundException {
+
+    public PatientNotFoundException(String id) {
+        super("Patient", id);
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/PayerNotFoundException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/PayerNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.edi.common.exception;
+
+public class PayerNotFoundException extends EntityNotFoundException {
+
+    public PayerNotFoundException(String id) {
+        super("Payer", id);
+    }
+}

--- a/backend/common/src/main/java/com/example/edi/common/exception/PracticeNotFoundException.java
+++ b/backend/common/src/main/java/com/example/edi/common/exception/PracticeNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.edi.common.exception;
+
+public class PracticeNotFoundException extends EntityNotFoundException {
+
+    public PracticeNotFoundException(String id) {
+        super("Practice", id);
+    }
+}

--- a/backend/insurance-request-app/src/main/java/com/example/edi/insurancerequest/controller/GlobalExceptionHandler.java
+++ b/backend/insurance-request-app/src/main/java/com/example/edi/insurancerequest/controller/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.example.edi.insurancerequest.controller;
+
+import com.example.edi.common.dto.ErrorResponse;
+import com.example.edi.common.exception.EdiParseException;
+import com.example.edi.common.exception.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(404)
+                .body(ErrorResponse.notFound(ex.getEntityType(), ex.getEntityId()));
+    }
+
+    @ExceptionHandler(EdiParseException.class)
+    public ResponseEntity<ErrorResponse> handleEdiParse(EdiParseException ex) {
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.badRequest(ex.getMessage()));
+    }
+}

--- a/backend/insurance-request-app/src/main/java/com/example/edi/insurancerequest/service/InsuranceRequestService.java
+++ b/backend/insurance-request-app/src/main/java/com/example/edi/insurancerequest/service/InsuranceRequestService.java
@@ -6,6 +6,10 @@ import com.example.edi.common.document.Patient;
 import com.example.edi.common.document.PatientInsurance;
 import com.example.edi.common.document.Payer;
 import com.example.edi.common.document.Practice;
+import com.example.edi.common.exception.InsuranceNotFoundException;
+import com.example.edi.common.exception.PatientNotFoundException;
+import com.example.edi.common.exception.PayerNotFoundException;
+import com.example.edi.common.exception.PracticeNotFoundException;
 import com.example.edi.common.repository.PatientInsuranceRepository;
 import com.example.edi.common.repository.PatientRepository;
 import com.example.edi.common.repository.PayerRepository;
@@ -45,21 +49,20 @@ public class InsuranceRequestService {
     public String generateEligibilityInquiry(List<String> patientIds) {
         Practice practice = practiceRepository.findAll().stream()
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("No practice found in the system"));
+                .orElseThrow(() -> new PracticeNotFoundException("default"));
 
         List<EligibilityBundle> bundles = new ArrayList<>();
 
         for (String patientId : patientIds) {
             Patient patient = patientRepository.findById(patientId)
-                    .orElseThrow(() -> new RuntimeException("Patient not found: " + patientId));
+                    .orElseThrow(() -> new PatientNotFoundException(patientId));
 
             PatientInsurance insurance = patientInsuranceRepository
                     .findByPatientIdAndTerminationDateIsNull(patientId)
-                    .orElseThrow(() -> new RuntimeException(
-                            "Active insurance not found for patient: " + patientId));
+                    .orElseThrow(() -> new InsuranceNotFoundException(patientId));
 
             Payer payer = payerRepository.findById(insurance.getPayerId())
-                    .orElseThrow(() -> new RuntimeException("Payer not found: " + insurance.getPayerId()));
+                    .orElseThrow(() -> new PayerNotFoundException(insurance.getPayerId()));
 
             bundles.add(new EligibilityBundle(patient, insurance, payer));
         }

--- a/backend/insurance-request-app/src/test/java/com/example/edi/insurancerequest/EligibilityInquiryIT.java
+++ b/backend/insurance-request-app/src/test/java/com/example/edi/insurancerequest/EligibilityInquiryIT.java
@@ -193,7 +193,7 @@ class EligibilityInquiryIT {
     }
 
     @Test
-    void eligibilityRequest_unknownPatient_returns500() {
+    void eligibilityRequest_unknownPatient_returns404() {
         Map<String, Object> requestBody = Map.of("patientIds", List.of("NONEXISTENT"));
 
         ResponseEntity<String> response = restTemplate.postForEntity(
@@ -202,7 +202,7 @@ class EligibilityInquiryIT {
                 String.class
         );
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/backend/insurance-request-app/src/test/java/com/example/edi/insurancerequest/controller/InsuranceRequestControllerTest.java
+++ b/backend/insurance-request-app/src/test/java/com/example/edi/insurancerequest/controller/InsuranceRequestControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.edi.insurancerequest.controller;
 
+import com.example.edi.common.exception.PatientNotFoundException;
 import com.example.edi.insurancerequest.service.InsuranceRequestService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,5 +78,21 @@ class InsuranceRequestControllerTest {
                                 {"patientIds": [""]}
                                 """))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void requestEligibility_patientNotFound_returns404() throws Exception {
+        when(insuranceRequestService.generateEligibilityInquiry(List.of("P999")))
+                .thenThrow(new PatientNotFoundException("P999"));
+
+        mockMvc.perform(post("/api/insurance/eligibility-request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"patientIds": ["P999"]}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.entityType").value("Patient"))
+                .andExpect(jsonPath("$.entityId").value("P999"));
     }
 }

--- a/backend/insurance-request-app/src/test/java/com/example/edi/insurancerequest/service/InsuranceRequestServiceTest.java
+++ b/backend/insurance-request-app/src/test/java/com/example/edi/insurancerequest/service/InsuranceRequestServiceTest.java
@@ -7,6 +7,9 @@ import com.example.edi.common.document.Patient;
 import com.example.edi.common.document.PatientInsurance;
 import com.example.edi.common.document.Payer;
 import com.example.edi.common.document.Practice;
+import com.example.edi.common.exception.InsuranceNotFoundException;
+import com.example.edi.common.exception.PatientNotFoundException;
+import com.example.edi.common.exception.PracticeNotFoundException;
 import com.example.edi.common.repository.PatientInsuranceRepository;
 import com.example.edi.common.repository.PatientRepository;
 import com.example.edi.common.repository.PayerRepository;
@@ -82,17 +85,17 @@ class InsuranceRequestServiceTest {
     }
 
     @Test
-    void generateEligibilityInquiry_patientNotFound_throwsException() {
+    void generateEligibilityInquiry_patientNotFound_throwsPatientNotFoundException() {
         when(practiceRepository.findAll()).thenReturn(List.of(new Practice()));
         when(patientRepository.findById("P999")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.generateEligibilityInquiry(List.of("P999")))
-                .isInstanceOf(RuntimeException.class)
+                .isInstanceOf(PatientNotFoundException.class)
                 .hasMessageContaining("Patient not found");
     }
 
     @Test
-    void generateEligibilityInquiry_noActiveInsurance_throwsException() {
+    void generateEligibilityInquiry_noActiveInsurance_throwsInsuranceNotFoundException() {
         Patient patient = new Patient();
         patient.setId("P001");
 
@@ -102,16 +105,16 @@ class InsuranceRequestServiceTest {
                 .thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.generateEligibilityInquiry(List.of("P001")))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Active insurance not found");
+                .isInstanceOf(InsuranceNotFoundException.class)
+                .hasMessageContaining("Insurance not found");
     }
 
     @Test
-    void generateEligibilityInquiry_noPractice_throwsException() {
+    void generateEligibilityInquiry_noPractice_throwsPracticeNotFoundException() {
         when(practiceRepository.findAll()).thenReturn(List.of());
 
         assertThatThrownBy(() -> service.generateEligibilityInquiry(List.of("P001")))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("No practice found");
+                .isInstanceOf(PracticeNotFoundException.class)
+                .hasMessageContaining("Practice not found");
     }
 }

--- a/backend/insurance-response-app/src/main/java/com/example/edi/insuranceresponse/controller/GlobalExceptionHandler.java
+++ b/backend/insurance-response-app/src/main/java/com/example/edi/insuranceresponse/controller/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.example.edi.insuranceresponse.controller;
+
+import com.example.edi.common.dto.ErrorResponse;
+import com.example.edi.common.exception.EdiParseException;
+import com.example.edi.common.exception.EntityNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(404)
+                .body(ErrorResponse.notFound(ex.getEntityType(), ex.getEntityId()));
+    }
+
+    @ExceptionHandler(EdiParseException.class)
+    public ResponseEntity<ErrorResponse> handleEdiParse(EdiParseException ex) {
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.badRequest(ex.getMessage()));
+    }
+}

--- a/backend/insurance-response-app/src/main/java/com/example/edi/insuranceresponse/service/EDI271Parser.java
+++ b/backend/insurance-response-app/src/main/java/com/example/edi/insuranceresponse/service/EDI271Parser.java
@@ -1,5 +1,6 @@
 package com.example.edi.insuranceresponse.service;
 
+import com.example.edi.common.exception.EdiParseException;
 import com.example.edi.common.edi.loop.FunctionalGroup;
 import com.example.edi.common.edi.loop.InterchangeEnvelope;
 import com.example.edi.common.edi.loop.TransactionHeader;
@@ -258,10 +259,10 @@ public class EDI271Parser {
 
             return new EDI271Response(envelope, functionalGroup, transactionHeader, subscriberInfo, payerInfo, benefits);
 
-        } catch (RuntimeException e) {
+        } catch (EdiParseException e) {
             throw e;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to parse EDI 271 file: " + filePath, e);
+            throw new EdiParseException("Failed to parse EDI 271 file: " + filePath, e);
         }
     }
 

--- a/backend/insurance-response-app/src/main/java/com/example/edi/insuranceresponse/service/EligibilityResponseService.java
+++ b/backend/insurance-response-app/src/main/java/com/example/edi/insuranceresponse/service/EligibilityResponseService.java
@@ -36,17 +36,8 @@ public class EligibilityResponseService {
         var archivePath = archiveDir.resolve(filename);
         file.transferTo(archivePath.toFile());
 
-        try {
-            EDI271Response parsed = edi271Parser.parse(archivePath);
-            EligibilityResponse result = edi271Mapper.map(parsed, archivePath.toString(), LocalDateTime.now());
-            return eligibilityResponseRepository.save(result);
-        } catch (Exception e) {
-            EligibilityResponse errorResponse = new EligibilityResponse();
-            errorResponse.setStatus("ERROR");
-            errorResponse.setErrorMessage(e.getMessage());
-            errorResponse.setFilePath(archivePath.toString());
-            errorResponse.setReceivedAt(LocalDateTime.now());
-            return eligibilityResponseRepository.save(errorResponse);
-        }
+        EDI271Response parsed = edi271Parser.parse(archivePath);
+        EligibilityResponse result = edi271Mapper.map(parsed, archivePath.toString(), LocalDateTime.now());
+        return eligibilityResponseRepository.save(result);
     }
 }

--- a/backend/insurance-response-app/src/test/java/com/example/edi/insuranceresponse/EligibilityResponseIT.java
+++ b/backend/insurance-response-app/src/test/java/com/example/edi/insuranceresponse/EligibilityResponseIT.java
@@ -120,23 +120,23 @@ class EligibilityResponseIT {
     }
 
     @Test
-    void uploadMalformedFile_returnsErrorResponse() throws Exception {
+    void uploadMalformedFile_returns400() throws Exception {
         Path tempFile = tempDir.resolve("malformed_271.edi");
         Files.writeString(tempFile, "NOT AN EDI FILE");
 
         ResponseEntity<String> response = postFile(tempFile.toFile());
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 
         String body = response.getBody();
         assertThat(body).isNotNull();
 
         JsonNode json = objectMapper.readTree(body);
-        assertThat(json.get("status").asText()).isEqualTo("ERROR");
-        assertThat(json.has("errorMessage")).isTrue();
-        assertThat(json.get("errorMessage").asText()).isNotBlank();
+        assertThat(json.get("error").asText()).isEqualTo("BAD_REQUEST");
+        assertThat(json.has("message")).isTrue();
+        assertThat(json.get("message").asText()).isNotBlank();
 
-        assertThat(eligibilityResponseRepository.count()).isEqualTo(1);
+        assertThat(eligibilityResponseRepository.count()).isEqualTo(0);
     }
 
     @Test

--- a/backend/insurance-response-app/src/test/java/com/example/edi/insuranceresponse/controller/InsuranceResponseControllerTest.java
+++ b/backend/insurance-response-app/src/test/java/com/example/edi/insuranceresponse/controller/InsuranceResponseControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.edi.insuranceresponse.controller;
 
 import com.example.edi.common.document.EligibilityResponse;
+import com.example.edi.common.exception.EdiParseException;
 import com.example.edi.insuranceresponse.service.EligibilityResponseService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,5 +43,19 @@ class InsuranceResponseControllerTest {
     void processEligibilityResponse_noFile_returns400() throws Exception {
         mockMvc.perform(multipart("/api/insurance/eligibility-response"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void processEligibilityResponse_parseError_returns400() throws Exception {
+        when(eligibilityResponseService.processFile(any()))
+                .thenThrow(new EdiParseException("Failed to parse EDI 271 file", null));
+
+        MockMultipartFile file = new MockMultipartFile("file", "bad_271.edi",
+                "text/plain", "INVALID EDI".getBytes());
+
+        mockMvc.perform(multipart("/api/insurance/eligibility-response").file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("Failed to parse EDI 271 file"));
     }
 }

--- a/backend/insurance-response-app/src/test/java/com/example/edi/insuranceresponse/service/EligibilityResponseServiceTest.java
+++ b/backend/insurance-response-app/src/test/java/com/example/edi/insuranceresponse/service/EligibilityResponseServiceTest.java
@@ -1,14 +1,13 @@
 package com.example.edi.insuranceresponse.service;
 
 import com.example.edi.common.document.EligibilityResponse;
+import com.example.edi.common.exception.EdiParseException;
 import com.example.edi.common.repository.EligibilityResponseRepository;
 import com.example.edi.insuranceresponse.config.ArchiveProperties;
 import com.example.edi.insuranceresponse.domain.loop.EDI271Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
@@ -17,6 +16,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -71,17 +71,11 @@ class EligibilityResponseServiceTest {
     }
 
     @Test
-    void processFile_parseFailure_savesErrorDocument() throws Exception {
+    void processFile_parseFailure_throwsEdiParseException() throws Exception {
         when(archiveProperties.path()).thenReturn(tempDir.toString());
 
         when(edi271Parser.parse(any(Path.class)))
-                .thenThrow(new RuntimeException("Parse failed"));
-
-        ArgumentCaptor<EligibilityResponse> captor = ArgumentCaptor.forClass(EligibilityResponse.class);
-        EligibilityResponse errorResponse = new EligibilityResponse();
-        errorResponse.setStatus("ERROR");
-        errorResponse.setErrorMessage("Parse failed");
-        when(eligibilityResponseRepository.save(captor.capture())).thenReturn(errorResponse);
+                .thenThrow(new EdiParseException("Parse failed", null));
 
         MockMultipartFile file = new MockMultipartFile("file", "bad_271.edi",
                 "text/plain", "INVALID EDI".getBytes());
@@ -89,13 +83,10 @@ class EligibilityResponseServiceTest {
         EligibilityResponseService service = new EligibilityResponseService(
                 edi271Parser, edi271Mapper, eligibilityResponseRepository, archiveProperties);
 
-        EligibilityResponse result = service.processFile(file);
+        assertThatThrownBy(() -> service.processFile(file))
+                .isInstanceOf(EdiParseException.class)
+                .hasMessageContaining("Parse failed");
 
-        verify(eligibilityResponseRepository).save(any(EligibilityResponse.class));
-        EligibilityResponse captured = captor.getValue();
-        assertThat(captured.getStatus()).isEqualTo("ERROR");
-        assertThat(captured.getErrorMessage()).isEqualTo("Parse failed");
-        assertThat(captured.getFilePath()).isNotNull();
-        assertThat(captured.getReceivedAt()).isNotNull();
+        verify(eligibilityResponseRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
…rors

Entity-not-found errors now return 404 (was 500) with structured ErrorResponse JSON. EDI parse errors now return 400 (was 200 with error embedded in body). EDI generation failures remain 500. Adds typed exception hierarchy in common module and GlobalExceptionHandler per app.