### PR TITLE
fix: add prior-auth-app build.gradle to all Dockerfiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,8 @@ When adding a new backend microservice, the following must ALL be addressed — 
 5. **GCP Secret Manager secrets** — Create `<app>-api-url-dev` and `<app>-api-url-prod` secrets containing the Cloud Run service URL
 6. **Frontend deploy secrets** — Add the new `<APP>_API_URL=<app>-api-url-<env>:latest` to the frontend's `--set-secrets` in the CI/CD workflow (both dev and prod)
 
+7. **Update ALL existing Dockerfiles** — Every existing app's Dockerfile must `COPY` the new module's `build.gradle` because `settings.gradle` includes all modules and Gradle configures them all during any build. Without this, Docker builds of other apps will fail with "Configuring project without an existing directory is not allowed."
+
 Missing any of these steps will result in the service not being deployed or the frontend not being able to reach it in cloud environments.
 
 ## Async Data Fetching

--- a/backend/claims-app/Dockerfile
+++ b/backend/claims-app/Dockerfile
@@ -11,6 +11,7 @@ COPY backend/common/build.gradle backend/common/build.gradle
 COPY backend/claims-app/build.gradle backend/claims-app/build.gradle
 COPY backend/insurance-request-app/build.gradle backend/insurance-request-app/build.gradle
 COPY backend/insurance-response-app/build.gradle backend/insurance-response-app/build.gradle
+COPY backend/prior-auth-app/build.gradle backend/prior-auth-app/build.gradle
 
 # Download dependencies (cached unless build files change)
 RUN ./gradlew dependencies --no-daemon || true

--- a/backend/insurance-request-app/Dockerfile
+++ b/backend/insurance-request-app/Dockerfile
@@ -11,6 +11,7 @@ COPY backend/common/build.gradle backend/common/build.gradle
 COPY backend/claims-app/build.gradle backend/claims-app/build.gradle
 COPY backend/insurance-request-app/build.gradle backend/insurance-request-app/build.gradle
 COPY backend/insurance-response-app/build.gradle backend/insurance-response-app/build.gradle
+COPY backend/prior-auth-app/build.gradle backend/prior-auth-app/build.gradle
 
 # Download dependencies (cached unless build files change)
 RUN ./gradlew dependencies --no-daemon || true

--- a/backend/insurance-response-app/Dockerfile
+++ b/backend/insurance-response-app/Dockerfile
@@ -11,6 +11,7 @@ COPY backend/common/build.gradle backend/common/build.gradle
 COPY backend/claims-app/build.gradle backend/claims-app/build.gradle
 COPY backend/insurance-request-app/build.gradle backend/insurance-request-app/build.gradle
 COPY backend/insurance-response-app/build.gradle backend/insurance-response-app/build.gradle
+COPY backend/prior-auth-app/build.gradle backend/prior-auth-app/build.gradle
 
 # Download dependencies (cached unless build files change)
 RUN ./gradlew dependencies --no-daemon || true


### PR DESCRIPTION
## Summary

- Add `COPY backend/prior-auth-app/build.gradle` to all existing Dockerfiles (claims-app, insurance-request-app, insurance-response-app)
- Add Dockerfile update step (#7) to the New Microservice Checklist in CLAUDE.md

These commits were pushed to PR #29 after it was merged, so they need a separate PR.

## Context

Since `settings.gradle` now includes `prior-auth-app`, Gradle configures all modules during any build. Without the build.gradle present, Docker builds of other apps fail with: "Configuring project without an existing directory is not allowed."

## Test plan

- [x] Verified `./gradlew build` passes locally
- [ ] CI builds all Docker images successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)